### PR TITLE
feat(auth): basic routes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm run typecheck
 
   test:
-    name: Unit Tests
+    name: Tests
     runs-on: ubuntu-latest
     needs: lint
 
@@ -42,14 +42,28 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-          cache: 'npm'
+      - name: Copy .env
+        run: cp .env.test .env
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and start containers
+        run: docker compose up -d
+
+      - name: Wait for database to be ready
+        run: sleep 10
+
+      - name: Run migrations
+        run: docker compose exec -T app node ace migration:run
 
       - name: Run tests
-        run: npm test
+        run: docker compose exec -T app npm test
+
+      - name: Show logs in case of failure
+        if: failure()
+        run: docker compose logs
+
+      - name: Stop containers
+        if: always()
+        run: docker compose down -v

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -64,9 +64,19 @@ tasks:
 
   # Development commands
   test:
-    desc: Run tests
+    desc: Run tests (optional args - use test:unit or test:functional for specific suites)
     cmds:
-      - docker compose exec app npm test
+      - docker compose exec app npm test {{.CLI_ARGS}}
+
+  test:unit:
+    desc: Run unit tests only
+    cmds:
+      - docker compose exec app node ace test unit {{.CLI_ARGS}}
+
+  test:functional:
+    desc: Run functional tests only
+    cmds:
+      - docker compose exec app node ace test functional {{.CLI_ARGS}}
 
   lint:
     desc: Run linting

--- a/app/controllers/auth_controller.ts
+++ b/app/controllers/auth_controller.ts
@@ -1,0 +1,42 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { loginValidator, registerValidator } from '#validators/auth'
+import AuthService from '#services/auth_service'
+import { inject } from '@adonisjs/core'
+
+@inject()
+export default class AuthController {
+  constructor(protected authService: AuthService) {}
+
+  /**
+   * Register a new user
+   */
+  async register({ request, response }: HttpContext) {
+    const data = await request.validateUsing(registerValidator)
+
+    const result = await this.authService.register(data)
+
+    return response.created(result)
+  }
+
+  /**
+   * Login user
+   */
+  async login({ request, response }: HttpContext) {
+    const data = await request.validateUsing(loginValidator)
+
+    const result = await this.authService.login(data)
+
+    return response.ok(result)
+  }
+
+  async me({ auth, response }: HttpContext) {
+    const user = auth.user!
+    return response.ok({
+      user: {
+        id: user.id,
+        email: user.email,
+        fullName: user.fullName,
+      },
+    })
+  }
+}

--- a/app/exceptions/duplicate_email_exception.ts
+++ b/app/exceptions/duplicate_email_exception.ts
@@ -1,0 +1,23 @@
+import { Exception } from '@adonisjs/core/exceptions'
+import type { HttpContext } from '@adonisjs/core/http'
+
+export default class DuplicateEmailException extends Exception {
+  static status = 409
+  static code = 'E_DUPLICATE_EMAIL'
+
+  constructor(public email: string) {
+    super()
+  }
+
+  async handle(error: this, { response }: HttpContext) {
+    response.status(error.status).send({
+      code: error.code,
+      message: `Email address "${this.email}" is already registered`,
+      status: error.status,
+    })
+  }
+
+  async report(error: this, { logger }: HttpContext) {
+    logger.warn({ email: error.email }, 'Registration attempt with existing email')
+  }
+}

--- a/app/exceptions/invalid_credentials_exception.ts
+++ b/app/exceptions/invalid_credentials_exception.ts
@@ -1,0 +1,15 @@
+import { Exception } from '@adonisjs/core/exceptions'
+import type { HttpContext } from '@adonisjs/core/http'
+
+export default class InvalidCredentialsException extends Exception {
+  static status = 401
+  static code = 'E_INVALID_CREDENTIALS'
+
+  async handle(error: this, { response }: HttpContext) {
+    response.status(error.status).send({
+      code: error.code,
+      message: 'Invalid credentials',
+      status: error.status,
+    })
+  }
+}

--- a/app/exceptions/server_error_exception.ts
+++ b/app/exceptions/server_error_exception.ts
@@ -1,0 +1,19 @@
+import { Exception } from '@adonisjs/core/exceptions'
+import type { HttpContext } from '@adonisjs/core/http'
+
+export default class ServerErrorException extends Exception {
+  static status = 500
+  static code = 'E_SERVER_ERROR'
+
+  async handle(error: this, { response }: HttpContext) {
+    response.status(error.status).send({
+      code: error.code,
+      message: error.message || 'Internal server error',
+      status: error.status,
+    })
+  }
+
+  async report(error: this, { logger }: HttpContext) {
+    logger.error({ err: error, stack: error.stack }, 'Server error occurred: %s', error.message)
+  }
+}

--- a/app/exceptions/unauthorized_exception.ts
+++ b/app/exceptions/unauthorized_exception.ts
@@ -1,0 +1,19 @@
+import { Exception } from '@adonisjs/core/exceptions'
+import type { HttpContext } from '@adonisjs/core/http'
+
+export default class UnauthorizedException extends Exception {
+  static status = 401
+  static code = 'E_UNAUTHORIZED'
+
+  constructor(message = 'Unauthorized access') {
+    super(message)
+  }
+
+  async handle(error: this, { response }: HttpContext) {
+    response.status(error.status).send({
+      code: error.code,
+      message: error.message,
+      status: error.status,
+    })
+  }
+}

--- a/app/middleware/auth_middleware.ts
+++ b/app/middleware/auth_middleware.ts
@@ -1,6 +1,7 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import type { NextFn } from '@adonisjs/core/types/http'
 import type { Authenticators } from '@adonisjs/auth/types'
+import UnauthorizedException from '#exceptions/unauthorized_exception'
 
 /**
  * Auth middleware is used authenticate HTTP requests and deny
@@ -19,7 +20,11 @@ export default class AuthMiddleware {
       guards?: (keyof Authenticators)[]
     } = {}
   ) {
-    await ctx.auth.authenticateUsing(options.guards, { loginRoute: this.redirectTo })
-    return next()
+    try {
+      await ctx.auth.authenticateUsing(options.guards, { loginRoute: this.redirectTo })
+      return next()
+    } catch (error) {
+      throw new UnauthorizedException()
+    }
   }
 }

--- a/app/models/user.ts
+++ b/app/models/user.ts
@@ -1,7 +1,8 @@
 import { DateTime } from 'luxon'
+import { v4 as uuidv4 } from 'uuid'
 import hash from '@adonisjs/core/services/hash'
 import { compose } from '@adonisjs/core/helpers'
-import { BaseModel, column } from '@adonisjs/lucid/orm'
+import { BaseModel, column, beforeCreate } from '@adonisjs/lucid/orm'
 import { withAuthFinder } from '@adonisjs/auth/mixins/lucid'
 import { DbAccessTokensProvider } from '@adonisjs/auth/access_tokens'
 
@@ -12,7 +13,7 @@ const AuthFinder = withAuthFinder(() => hash.use('scrypt'), {
 
 export default class User extends compose(BaseModel, AuthFinder) {
   @column({ isPrimary: true })
-  declare id: number
+  declare id: string
 
   @column()
   declare fullName: string | null
@@ -30,4 +31,9 @@ export default class User extends compose(BaseModel, AuthFinder) {
   declare updatedAt: DateTime | null
 
   static accessTokens = DbAccessTokensProvider.forModel(User)
+
+  @beforeCreate()
+  static assignUuid(user: User) {
+    user.id = uuidv4()
+  }
 }

--- a/app/services/auth_service.ts
+++ b/app/services/auth_service.ts
@@ -1,0 +1,71 @@
+import User from '#models/user'
+import hash from '@adonisjs/core/services/hash'
+import TokenService from '#services/token_service'
+import { RegisterData, LoginData, TokenResponse } from '#types/auth'
+import DuplicateEmailException from '#exceptions/duplicate_email_exception'
+import InvalidCredentialsException from '#exceptions/invalid_credentials_exception'
+import ServerErrorException from '#exceptions/server_error_exception'
+import { inject } from '@adonisjs/core'
+
+@inject()
+export default class AuthService {
+  constructor(protected tokenService: TokenService) {}
+
+  /**
+   * Register a new user
+   */
+  async register(data: RegisterData): Promise<TokenResponse> {
+    try {
+      const user = await User.create({
+        email: data.email,
+        password: data.password,
+        fullName: data.fullName,
+      })
+
+      return this.#generateTokenResponse(user)
+    } catch (error) {
+      if (error.code === 'ER_DUP_ENTRY' || error.code === 'P2002') {
+        throw new DuplicateEmailException(data.email)
+      }
+
+      throw new ServerErrorException(`Unable to create account: ${error.message}`, {
+        cause: error,
+      })
+    }
+  }
+
+  /**
+   * Authenticate user with email verification and password validation
+   */
+  async login(data: LoginData): Promise<TokenResponse> {
+    const user = await User.findBy('email', data.email)
+    if (!user) {
+      throw new InvalidCredentialsException()
+    }
+
+    const passwordValid = await hash.verify(user.password, data.password)
+    if (!passwordValid) {
+      throw new InvalidCredentialsException()
+    }
+
+    return this.#generateTokenResponse(user)
+  }
+
+  /**
+   * Generate token and format response
+   * @private
+   */
+  async #generateTokenResponse(user: User): Promise<TokenResponse> {
+    const token = await this.tokenService.generateAuthToken(user)
+
+    return {
+      user: {
+        id: user.id,
+        email: user.email,
+        fullName: user.fullName,
+      },
+      token: token,
+      type: 'bearer',
+    }
+  }
+}

--- a/app/services/token_service.ts
+++ b/app/services/token_service.ts
@@ -1,0 +1,17 @@
+import { inject } from '@adonisjs/core'
+import User from '#models/user'
+
+@inject()
+export default class TokenService {
+  /**
+   * Generate an authentication token for a user
+   */
+  async generateAuthToken(user: User): Promise<string> {
+    const token = await User.accessTokens.create(user, ['*'], {
+      name: 'api_token',
+      expiresIn: '7days',
+    })
+
+    return token.value!.release()
+  }
+}

--- a/app/types/auth.ts
+++ b/app/types/auth.ts
@@ -1,0 +1,26 @@
+export interface RegisterData {
+  email: string
+  password: string
+  fullName?: string
+}
+
+export interface LoginData {
+  email: string
+  password: string
+}
+
+export interface TokenResponse {
+  user: {
+    id: string
+    email: string
+    fullName: string | null
+  }
+  token: string
+  type: string
+}
+
+export interface UserPayload {
+  id: string
+  email: string
+  fullName: string | null
+}

--- a/app/validators/auth.ts
+++ b/app/validators/auth.ts
@@ -1,0 +1,16 @@
+import vine from '@vinejs/vine'
+
+export const registerValidator = vine.compile(
+  vine.object({
+    email: vine.string().email().trim().toLowerCase(),
+    password: vine.string().minLength(8),
+    fullName: vine.string().trim().optional(),
+  })
+)
+
+export const loginValidator = vine.compile(
+  vine.object({
+    email: vine.string().email().trim().toLowerCase(),
+    password: vine.string(),
+  })
+)

--- a/database/factories/user_factory.ts
+++ b/database/factories/user_factory.ts
@@ -1,0 +1,14 @@
+import { v4 as uuidv4 } from 'uuid'
+import factory from '@adonisjs/lucid/factories'
+import User from '#models/user'
+
+export const UserFactory = factory
+  .define(User, async ({ faker }) => {
+    return {
+      id: uuidv4(),
+      email: faker.internet.email().toLowerCase(),
+      password: 'password123',
+      fullName: faker.person.fullName(),
+    }
+  })
+  .build()

--- a/database/migrations/1746194942667_create_users_table.ts
+++ b/database/migrations/1746194942667_create_users_table.ts
@@ -5,7 +5,7 @@ export default class extends BaseSchema {
 
   async up() {
     this.schema.createTable(this.tableName, (table) => {
-      table.increments('id').notNullable()
+      table.uuid('id').primary().notNullable()
       table.string('full_name').nullable()
       table.string('email', 254).notNullable().unique()
       table.string('password').notNullable()

--- a/database/migrations/1746194942671_create_access_tokens_table.ts
+++ b/database/migrations/1746194942671_create_access_tokens_table.ts
@@ -6,13 +6,7 @@ export default class extends BaseSchema {
   async up() {
     this.schema.createTable(this.tableName, (table) => {
       table.increments('id')
-      table
-        .integer('tokenable_id')
-        .notNullable()
-        .unsigned()
-        .references('id')
-        .inTable('users')
-        .onDelete('CASCADE')
+      table.uuid('tokenable_id').notNullable().references('id').inTable('users').onDelete('CASCADE')
 
       table.string('type').notNullable()
       table.string('name').nullable()

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "@vinejs/vine": "^3.0.0",
         "luxon": "^3.6.1",
         "mysql2": "^3.14.1",
-        "reflect-metadata": "^0.2.2"
+        "reflect-metadata": "^0.2.2",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@adonisjs/assembler": "^7.8.2",
@@ -30,6 +31,7 @@
         "@swc/core": "1.10.7",
         "@types/luxon": "^3.6.2",
         "@types/node": "^22.13.2",
+        "@types/uuid": "^10.0.0",
         "eslint": "^9.20.1",
         "hot-hook": "^0.4.0",
         "husky": "^9.1.7",
@@ -1747,6 +1749,12 @@
         "@types/node": "*",
         "form-data": "^4.0.0"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "dev": true
     },
     "node_modules/@types/validator": {
       "version": "13.15.0",
@@ -7007,6 +7015,18 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "#events/*": "./app/events/*.js",
     "#middleware/*": "./app/middleware/*.js",
     "#validators/*": "./app/validators/*.js",
+    "#types/*": "./app/types/*.js",
     "#providers/*": "./providers/*.js",
     "#policies/*": "./app/policies/*.js",
     "#abilities/*": "./app/abilities/*.js",
@@ -46,6 +47,7 @@
     "@swc/core": "1.10.7",
     "@types/luxon": "^3.6.2",
     "@types/node": "^22.13.2",
+    "@types/uuid": "^10.0.0",
     "eslint": "^9.20.1",
     "hot-hook": "^0.4.0",
     "husky": "^9.1.7",
@@ -63,7 +65,8 @@
     "@vinejs/vine": "^3.0.0",
     "luxon": "^3.6.1",
     "mysql2": "^3.14.1",
-    "reflect-metadata": "^0.2.2"
+    "reflect-metadata": "^0.2.2",
+    "uuid": "^11.1.0"
   },
   "hotHook": {
     "boundaries": [

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -1,13 +1,20 @@
 import router from '@adonisjs/core/services/router'
+import { middleware } from '#start/kernel'
+
 const HealthCheckController = () => import('#controllers/health_check_controller')
 const RootController = () => import('#controllers/root_controller')
 const ApiInfoController = () => import('#controllers/api_info_controller')
+const AuthController = () => import('#controllers/auth_controller')
 
-router.get('/', [RootController])
-router.get('/health', [HealthCheckController])
+router.get('/', [RootController, 'handle'])
+router.get('/health', [HealthCheckController, 'handle'])
 
 const apiV1 = router.group(() => {
-  router.get('/', [ApiInfoController])
+  router.get('/', [ApiInfoController, 'handle'])
+
+  router.post('/register', [AuthController, 'register'])
+  router.post('/login', [AuthController, 'login'])
+  router.get('/me', [AuthController, 'me']).use(middleware.auth())
 })
 
 apiV1.prefix('/api/v1')

--- a/tests/bootstrap.ts
+++ b/tests/bootstrap.ts
@@ -5,34 +5,15 @@ import type { Config } from '@japa/runner/types'
 import { pluginAdonisJS } from '@japa/plugin-adonisjs'
 import testUtils from '@adonisjs/core/services/test_utils'
 
-/**
- * This file is imported by the "bin/test.ts" entrypoint file
- */
-
-/**
- * Configure Japa plugins in the plugins array.
- * Learn more - https://japa.dev/docs/runner-config#plugins-optional
- */
 export const plugins: Config['plugins'] = [assert(), apiClient(), pluginAdonisJS(app)]
 
-/**
- * Configure lifecycle function to run before and after all the
- * tests.
- *
- * The setup functions are executed before all the tests
- * The teardown functions are executed after all the tests
- */
 export const runnerHooks: Required<Pick<Config, 'setup' | 'teardown'>> = {
-  setup: [],
+  setup: [() => testUtils.db().migrate()],
   teardown: [],
 }
 
-/**
- * Configure suites by tapping into the test suite instance.
- * Learn more - https://japa.dev/docs/test-suites#lifecycle-hooks
- */
 export const configureSuite: Config['configureSuite'] = (suite) => {
-  if (['browser', 'functional', 'e2e'].includes(suite.name)) {
+  if (['functional', 'e2e'].includes(suite.name)) {
     return suite.setup(() => testUtils.httpServer().start())
   }
 }

--- a/tests/functional/auth_controller.spec.ts
+++ b/tests/functional/auth_controller.spec.ts
@@ -1,0 +1,114 @@
+import { test } from '@japa/runner'
+import User from '#models/user'
+import testUtils from '@adonisjs/core/services/test_utils'
+import { UserFactory } from '#database/factories/user_factory'
+
+test.group('Authentication Controller', (group) => {
+  group.each.setup(() => testUtils.db().withGlobalTransaction())
+
+  test('register endpoint creates a new user and returns token', async ({ client, assert }) => {
+    const userData = {
+      email: 'test@example.com',
+      password: 'password123',
+      fullName: 'Test User',
+    }
+
+    const response = await client.post('/api/v1/register').json(userData)
+
+    response.assertStatus(201)
+    response.assertBodyContains({
+      user: {
+        email: userData.email,
+        fullName: userData.fullName,
+      },
+      type: 'bearer',
+    })
+
+    assert.exists(response.body().token)
+
+    const user = await User.findBy('email', userData.email)
+    assert.exists(user)
+  })
+
+  test('register endpoint returns 409 for duplicate email', async ({ client }) => {
+    const existingUser = await UserFactory.create()
+
+    const response = await client.post('/api/v1/register').json({
+      email: existingUser.email,
+      password: 'password123',
+      fullName: 'Duplicate User',
+    })
+
+    response.assertStatus(409)
+    response.assertBodyContains({
+      code: 'E_DUPLICATE_EMAIL',
+    })
+  })
+
+  test('login endpoint returns token for valid credentials', async ({ client, assert }) => {
+    const user = await UserFactory.create()
+
+    const response = await client.post('/api/v1/login').json({
+      email: user.email,
+      password: 'password123',
+    })
+
+    response.assertStatus(200)
+    response.assertBodyContains({
+      user: {
+        email: user.email,
+        fullName: user.fullName,
+      },
+      type: 'bearer',
+    })
+
+    assert.exists(response.body().token)
+  })
+
+  test('login endpoint returns 401 for invalid credentials', async ({ client }) => {
+    const user = await UserFactory.create()
+
+    const response = await client.post('/api/v1/login').json({
+      email: user.email,
+      password: 'wrongpassword',
+    })
+
+    response.assertStatus(401)
+    response.assertBodyContains({
+      code: 'E_INVALID_CREDENTIALS',
+    })
+  })
+
+  test('me endpoint returns user information when authenticated', async ({ client }) => {
+    const user = await UserFactory.merge({
+      email: 'me@example.com',
+      fullName: 'Me User',
+    }).create()
+
+    const loginResponse = await client.post('/api/v1/login').json({
+      email: user.email,
+      password: 'password123',
+    })
+
+    const token = loginResponse.body().token
+
+    const response = await client.get('/api/v1/me').header('Authorization', `Bearer ${token}`)
+
+    response.assertStatus(200)
+    response.assertBodyContains({
+      user: {
+        email: user.email,
+        fullName: user.fullName,
+      },
+    })
+  })
+
+  test('me endpoint returns 401 when not authenticated', async ({ client }) => {
+    const response = await client.get('/api/v1/me')
+
+    response.assertStatus(401)
+    response.assertBodyContains({
+      code: 'E_UNAUTHORIZED',
+    })
+  })
+})

--- a/tests/unit/auth_service.spec.ts
+++ b/tests/unit/auth_service.spec.ts
@@ -1,0 +1,96 @@
+import { test } from '@japa/runner'
+import AuthService from '#services/auth_service'
+import TokenService from '#services/token_service'
+import User from '#models/user'
+import hash from '@adonisjs/core/services/hash'
+import testUtils from '@adonisjs/core/services/test_utils'
+import DuplicateEmailException from '#exceptions/duplicate_email_exception'
+import InvalidCredentialsException from '#exceptions/invalid_credentials_exception'
+import { UserFactory } from '#database/factories/user_factory'
+
+test.group('Auth Service', (group) => {
+  let authService: AuthService
+
+  group.each.setup(() => {
+    const tokenService = new TokenService()
+    authService = new AuthService(tokenService)
+
+    return testUtils.db().withGlobalTransaction()
+  })
+
+  test('register creates a new user and returns token response', async ({ assert }) => {
+    const userData = {
+      email: 'test@example.com',
+      password: 'password123',
+      fullName: 'Test User',
+    }
+
+    const result = await authService.register(userData)
+
+    assert.exists(result.token)
+    assert.equal(result.type, 'bearer')
+    assert.equal(result.user.email, userData.email)
+    assert.equal(result.user.fullName, userData.fullName)
+
+    const user = await User.findBy('email', userData.email)
+    assert.exists(user)
+
+    assert.isTrue(await hash.verify(user!.password, userData.password))
+  })
+
+  test('register throws DuplicateEmailException for existing email', async ({ assert }) => {
+    const existingUser = await UserFactory.create()
+
+    try {
+      await authService.register({
+        email: existingUser.email,
+        password: 'password123',
+        fullName: 'Duplicate User',
+      })
+      assert.fail('Should have thrown DuplicateEmailException')
+    } catch (error) {
+      assert.instanceOf(error, DuplicateEmailException)
+      assert.equal(error.email, existingUser.email)
+    }
+  })
+
+  test('login authenticates user and returns token response', async ({ assert }) => {
+    const user = await UserFactory.create()
+
+    const result = await authService.login({
+      email: user.email,
+      password: 'password123',
+    })
+
+    assert.exists(result.token)
+    assert.equal(result.type, 'bearer')
+    assert.equal(result.user.email, user.email)
+    assert.equal(result.user.fullName, user.fullName)
+  })
+
+  test('login throws InvalidCredentialsException for wrong email', async ({ assert }) => {
+    try {
+      await authService.login({
+        email: 'nonexistent@example.com',
+        password: 'password123',
+      })
+      assert.fail('Should have thrown InvalidCredentialsException')
+    } catch (error) {
+      assert.instanceOf(error, InvalidCredentialsException)
+    }
+  })
+
+  test('login throws InvalidCredentialsException for wrong password', async ({ assert }) => {
+    const user = await UserFactory.create()
+
+    try {
+      await authService.login({
+        email: user.email,
+        password: 'wrongpassword',
+      })
+      assert.fail('Should have thrown InvalidCredentialsException')
+    } catch (error) {
+      assert.instanceOf(error, InvalidCredentialsException)
+    }
+  })
+})

--- a/tests/unit/token_service.spec.ts
+++ b/tests/unit/token_service.spec.ts
@@ -1,0 +1,43 @@
+import { test } from '@japa/runner'
+import TokenService from '#services/token_service'
+import User from '#models/user'
+import testUtils from '@adonisjs/core/services/test_utils'
+import { UserFactory } from '#database/factories/user_factory'
+
+test.group('Token Service', (group) => {
+  let tokenService: TokenService
+  let user: User
+
+  group.setup(async () => {
+    user = await UserFactory.create()
+  })
+
+  group.each.setup(() => {
+    tokenService = new TokenService()
+    return testUtils.db().withGlobalTransaction()
+  })
+
+  test('generateAuthToken returns a valid token', async ({ assert }) => {
+    const token = await tokenService.generateAuthToken(user)
+
+    assert.isString(token)
+    assert.isNotEmpty(token)
+    assert.notEqual(token, 'password123')
+  })
+
+  test('generates unique tokens for the same user', async ({ assert }) => {
+    const token1 = await tokenService.generateAuthToken(user)
+    const token2 = await tokenService.generateAuthToken(user)
+
+    assert.notEqual(token1, token2)
+  })
+
+  test('different users get different tokens', async ({ assert }) => {
+    const secondUser = await UserFactory.create()
+
+    const token1 = await tokenService.generateAuthToken(user)
+    const token2 = await tokenService.generateAuthToken(secondUser)
+
+    assert.notEqual(token1, token2)
+  })
+})


### PR DESCRIPTION
- Added basic auth endpoints: /api/v1/register, /api/v1/login and /api/v1/me
- Implemented token-based authentication using AdonisJS Auth module
- Added UUID support for user IDs for better security and distribution
- Built test suite
- Set up CI pipeline with GitHub Actions:
- Added error handling for common auth scenarios
- Configured Docker for consistent development & testing environments
