### PR TITLE
fix(validators): enhance password validation rules in registerValidator

### DIFF
--- a/app/validators/auth.ts
+++ b/app/validators/auth.ts
@@ -3,7 +3,11 @@ import vine from '@vinejs/vine'
 export const registerValidator = vine.compile(
   vine.object({
     email: vine.string().email().trim().toLowerCase(),
-    password: vine.string().minLength(8),
+    password: vine
+      .string()
+      .minLength(8)
+      .maxLength(64)
+      .regex(/^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,64}$/),
     fullName: vine.string().trim().optional(),
   })
 )

--- a/database/factories/user_factory.ts
+++ b/database/factories/user_factory.ts
@@ -7,7 +7,7 @@ export const UserFactory = factory
     return {
       id: uuidv4(),
       email: faker.internet.email().toLowerCase(),
-      password: 'password123',
+      password: 'Password123*',
       fullName: faker.person.fullName(),
     }
   })

--- a/tests/functional/auth_controller.spec.ts
+++ b/tests/functional/auth_controller.spec.ts
@@ -23,7 +23,7 @@ test.group('Authentication Controller', (group) => {
   }) => {
     const userData = {
       email: 'test@example.com',
-      password: 'password123',
+      password: 'Password123*',
       fullName: 'Test User',
     }
 
@@ -56,7 +56,7 @@ test.group('Authentication Controller', (group) => {
 
     const response = await client.post('/api/v1/register').json({
       email: existingUser.email,
-      password: 'password123',
+      password: 'Password123*',
       fullName: 'Duplicate User',
     })
 
@@ -73,7 +73,7 @@ test.group('Authentication Controller', (group) => {
 
     const response = await client.post('/api/v1/login').json({
       email: user.email,
-      password: 'password123',
+      password: 'Password123*',
     })
 
     response.assertStatus(200)
@@ -95,7 +95,7 @@ test.group('Authentication Controller', (group) => {
 
     const response = await client.post('/api/v1/login').json({
       email: user.email,
-      password: 'password123',
+      password: 'Password123*',
     })
 
     response.assertStatus(403)
@@ -129,7 +129,7 @@ test.group('Authentication Controller', (group) => {
 
     const loginResponse = await client.post('/api/v1/login').json({
       email: user.email,
-      password: 'password123',
+      password: 'Password123*',
     })
 
     const token = loginResponse.body().token

--- a/tests/functional/email_verification_flow.spec.ts
+++ b/tests/functional/email_verification_flow.spec.ts
@@ -22,7 +22,7 @@ test.group('Email Verification Flow', (group) => {
     // 1. Register a new user
     const userData = {
       email: 'newuser@example.com',
-      password: 'password123',
+      password: 'Password123*',
       fullName: 'New User',
     }
 
@@ -92,14 +92,14 @@ test.group('Email Verification Flow', (group) => {
     // Create an unverified user directly
     const user = await UserFactory.merge({
       email: 'unverified@example.com',
-      password: 'password123',
+      password: 'Password123*',
       isVerified: false,
     }).create()
 
     // Try to login
     const loginResponse = await client.post('/api/v1/login').json({
       email: user.email,
-      password: 'password123',
+      password: 'Password123*',
     })
 
     // Should fail with email not verified error

--- a/tests/unit/auth_service.spec.ts
+++ b/tests/unit/auth_service.spec.ts
@@ -49,7 +49,7 @@ test.group('Auth Service', (group) => {
   test('register creates a new user and returns token response', async ({ assert }) => {
     const userData = {
       email: 'test@example.com',
-      password: 'password123',
+      password: 'Password123*',
       fullName: 'Test User',
     }
 
@@ -83,7 +83,7 @@ test.group('Auth Service', (group) => {
     try {
       await authService.register({
         email: existingUser.email,
-        password: 'password123',
+        password: 'Password123*',
         fullName: 'Duplicate User',
       })
       assert.fail('Should have thrown DuplicateEmailException')
@@ -100,7 +100,7 @@ test.group('Auth Service', (group) => {
 
     const result = await authService.login({
       email: user.email,
-      password: 'password123',
+      password: 'Password123*',
     })
 
     assert.exists(result.token)
@@ -118,7 +118,7 @@ test.group('Auth Service', (group) => {
     try {
       await authService.login({
         email: user.email,
-        password: 'password123',
+        password: 'Password123*',
       })
       assert.fail('Should have thrown EmailNotVerifiedException')
     } catch (error) {
@@ -130,7 +130,7 @@ test.group('Auth Service', (group) => {
     try {
       await authService.login({
         email: 'nonexistent@example.com',
-        password: 'password123',
+        password: 'Password123*',
       })
       assert.fail('Should have thrown InvalidCredentialsException')
     } catch (error) {

--- a/tests/unit/register_validator.spec.ts
+++ b/tests/unit/register_validator.spec.ts
@@ -1,0 +1,31 @@
+import { test } from '@japa/runner'
+import { registerValidator } from '#validators/auth'
+
+test.group('Register Validator', () => {
+  test('accepts a valid password', async ({ assert }) => {
+    const data = {
+      email: 'test@example.com',
+      password: 'Valid1@Password',
+      fullName: 'Test User',
+    }
+
+    const result = await registerValidator.validate(data)
+    assert.equal(result.password, data.password)
+  })
+
+  test('rejects a password that does not meet complexity', async ({ assert }) => {
+    const data = {
+      email: 'test@example.com',
+      password: 'simplepass',
+      fullName: 'Test User',
+    }
+
+    try {
+      await registerValidator.validate(data)
+      assert.fail('Validation should have failed for weak password')
+    } catch (error) {
+      assert.exists(error)
+      assert.match(error.messages[0].message, /The password field format is invalid/)
+    }
+  })
+})


### PR DESCRIPTION
## 📝 Description

Modification des règles de validation au niveau du sign-up pour avoir une validation de password un peu plus stricte :

* 8 à 64 caractères
* Au moins une majuscule
* Au moins une minuscule
* Au moins un chiffre
* Au moins un caractère spécial

Related task : [WAR-28](https://sleeved.atlassian.net/browse/WAR-28)

## 📸 Screenshots / Demo

<img width="1022" height="847" alt="image" src="https://github.com/user-attachments/assets/0f4caecf-b626-42db-81d3-c6d51e8c32c9" />
<img width="1022" height="847" alt="image" src="https://github.com/user-attachments/assets/1230ae3f-5490-421e-ba16-1c4def797338" />


## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Performance optimization verified (if applicable)
- [ ] Documentation updated (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[WAR-28]: https://sleeved.atlassian.net/browse/WAR-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ