### PR TITLE
feat(token): refresh token logic

### DIFF
--- a/app/controllers/email_verification_controller.ts
+++ b/app/controllers/email_verification_controller.ts
@@ -29,12 +29,14 @@ export default class EmailVerificationController {
 
     // Generate auth token for the user
     const token = await this.tokenService.generateAuthToken(user)
+    const refreshToken = await this.tokenService.generateRefreshToken(user)
 
     return response.json({
       status: true,
       message: 'Email verified successfully',
       user: this.authService.formatUserForResponse(user),
       token,
+      refreshToken: refreshToken.token,
       type: 'bearer',
     })
   }

--- a/app/controllers/token_controller.ts
+++ b/app/controllers/token_controller.ts
@@ -1,0 +1,18 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { inject } from '@adonisjs/core'
+import TokenService from '#services/token_service'
+import { refreshTokenValidator } from '#validators/refresh_token'
+
+@inject()
+export default class TokenController {
+  constructor(protected tokenService: TokenService) {}
+
+  /**
+   * Refresh an access token using a refresh token
+   */
+  async refresh({ request, response }: HttpContext) {
+    const { refreshToken } = await request.validateUsing(refreshTokenValidator)
+    const result = await this.tokenService.refreshToken(refreshToken)
+    return response.ok(result)
+  }
+}

--- a/app/exceptions/invalid_refresh_token_exception.ts
+++ b/app/exceptions/invalid_refresh_token_exception.ts
@@ -1,0 +1,19 @@
+import { Exception } from '@adonisjs/core/exceptions'
+import type { HttpContext } from '@adonisjs/core/http'
+
+export default class InvalidRefreshTokenException extends Exception {
+  static status = 401
+  static code = 'E_INVALID_REFRESH_TOKEN'
+
+  constructor(message = 'Invalid or expired refresh token') {
+    super(message)
+  }
+
+  async handle(error: this, { response }: HttpContext) {
+    response.status(error.status).json({
+      code: error.code,
+      message: error.message,
+      status: false,
+    })
+  }
+}

--- a/app/services/auth_service.ts
+++ b/app/services/auth_service.ts
@@ -98,11 +98,13 @@ export default class AuthService {
    * @private
    */
   async #generateTokenResponse(user: User): Promise<TokenResponse> {
-    const token = await this.tokenService.generateAuthToken(user)
+    const refresh = await this.tokenService.generateRefreshToken(user)
+    const token = await this.tokenService.generateAuthToken(user, refresh.id)
 
     return {
       user: this.formatUserForResponse(user),
       token: token,
+      refreshToken: refresh.token,
       type: 'bearer',
     }
   }

--- a/app/services/token_service.ts
+++ b/app/services/token_service.ts
@@ -1,17 +1,77 @@
 import { inject } from '@adonisjs/core'
+import { Secret } from '@adonisjs/core/helpers'
 import User from '#models/user'
+import { TokenRefreshResponse } from '#types/auth'
+import db from '@adonisjs/lucid/services/db'
+import InvalidRefreshTokenException from '#exceptions/invalid_refresh_token_exception'
 
 @inject()
 export default class TokenService {
   /**
-   * Generate an authentication token for a user
+   * Generate an access token. If refreshTokenId is provided, link via parent_id
    */
-  async generateAuthToken(user: User): Promise<string> {
+  async generateAuthToken(user: User, refreshTokenId?: number): Promise<string> {
     const token = await User.accessTokens.create(user, ['*'], {
       name: 'api_token',
-      expiresIn: '7days',
+      expiresIn: '15mins',
     })
 
+    if (refreshTokenId) {
+      await db
+        .query()
+        .from('auth_access_tokens')
+        .where('id', Number(token.identifier))
+        .update({ parent_id: refreshTokenId })
+    }
+
     return token.value!.release()
+  }
+
+  /**
+   * Generate a refresh token and return both the public value
+   */
+  async generateRefreshToken(user: User): Promise<{ token: string; id: number }> {
+    const token = await User.accessTokens.create(user, ['refresh'], {
+      name: 'refresh_token',
+      expiresIn: '30days',
+    })
+
+    return { token: token.value!.release(), id: Number(token.identifier) }
+  }
+
+  /**
+   * Exchange a refresh token for a new access token
+   */
+  async refreshToken(
+    refreshToken: string
+  ): Promise<TokenRefreshResponse & { refreshToken?: string }> {
+    const tokenSecret = new Secret(refreshToken)
+    const token = await User.accessTokens.verify(tokenSecret)
+
+    if (!token || !token.allows?.('refresh')) {
+      throw new InvalidRefreshTokenException()
+    }
+
+    const user = await User.findOrFail(token.tokenableId)
+
+    // issue a new refresh token (rotation)
+    const newRefresh = await this.generateRefreshToken(user)
+
+    // issue a new access token linked to the new refresh token
+    const accessToken = await this.generateAuthToken(user, Number(newRefresh.id))
+
+    // revoke the used refresh token to prevent reuse
+    await db
+      .query()
+      .from('auth_access_tokens')
+      .where('parent_id', Number(token.identifier))
+      .delete()
+    await db.query().from('auth_access_tokens').where('id', Number(token.identifier)).delete()
+
+    return {
+      token: accessToken,
+      refreshToken: newRefresh.token,
+      type: 'bearer',
+    }
   }
 }

--- a/app/types/auth.ts
+++ b/app/types/auth.ts
@@ -12,6 +12,12 @@ export interface LoginData {
 export interface TokenResponse {
   user: UserPayload
   token: string
+  refreshToken: string
+  type: string
+}
+
+export interface TokenRefreshResponse {
+  token: string
   type: string
 }
 

--- a/app/validators/refresh_token.ts
+++ b/app/validators/refresh_token.ts
@@ -1,0 +1,7 @@
+import vine from '@vinejs/vine'
+
+export const refreshTokenValidator = vine.compile(
+  vine.object({
+    refreshToken: vine.string(),
+  })
+)

--- a/database/migrations/1756473320208_create_add_refresh_token_fields_table.ts
+++ b/database/migrations/1756473320208_create_add_refresh_token_fields_table.ts
@@ -1,0 +1,19 @@
+// database/migrations/xxx_add_refresh_token_fields.ts
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'auth_access_tokens'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.integer('parent_id').unsigned().nullable().references('id').inTable(this.tableName)
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropForeign(['parent_id'])
+      table.dropColumn('parent_id')
+    })
+  }
+}

--- a/resources/swagger.json
+++ b/resources/swagger.json
@@ -43,7 +43,7 @@
       "post": {
         "summary": "Login with email and password",
         "tags": ["Auth"],
-        "description": "Login and receive a bearer token. Copy the `token` from the response and use it as a Bearer token in the Authorization header for authenticated requests (e.g. `/me`).",
+        "description": "Login and receive a bearer token and a refresh token. Use the returned `token` as a Bearer token in the Authorization header for authenticated requests (e.g. `/me`).",
         "requestBody": {
           "required": true,
           "content": {
@@ -65,7 +65,12 @@
         },
         "responses": {
           "200": {
-            "description": "Login successful. Use the returned `token` as a Bearer token in the Authorization header for authenticated requests (see Authorize button above)."
+            "description": "Login successful. Response includes access token and refresh token.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TokenResponse" }
+              }
+            }
           },
           "401": { "description": "Invalid credentials" },
           "403": { "description": "Email not verified" }
@@ -137,8 +142,51 @@
         "description": "Requires a valid Bearer token in the Authorization header. Use the Authorize button above or add the header manually: `Authorization: Bearer <token>`.",
         "security": [{ "bearerAuth": [] }],
         "responses": {
-          "200": { "description": "User info" },
+          "200": {
+            "description": "User info",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UserResponse" }
+              }
+            }
+          },
           "401": { "description": "Unauthorized" }
+        }
+      }
+    },
+    "/refresh-token": {
+      "post": {
+        "summary": "Refresh access token",
+        "tags": ["Auth"],
+        "description": "Exchange a refresh token for a new short-lived access token. Provide the refresh token received at login.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/RefreshRequest" },
+              "example": {
+                "refreshToken": "oat_NQ.OE1CMUpqVnJUdGp1S3hNcjhlSkh6UTlLVHYzcUVMZ2tncHltbjA0eDY1NDIwNzM2"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "New access token issued",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RefreshResponse" }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or expired refresh token",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          }
         }
       }
     }
@@ -148,6 +196,64 @@
       "bearerAuth": {
         "type": "http",
         "scheme": "bearer"
+      }
+    },
+    "schemas": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "example": "34261c3d-63ba-4bc0-aba2-b70ac39e515c" },
+          "email": { "type": "string", "format": "email", "example": "alice@example.com" },
+          "username": { "type": ["string", "null"], "example": "Alice Doe" },
+          "isVerified": { "type": "integer", "example": 1 },
+          "role": { "type": "string", "example": "user" }
+        }
+      },
+      "UserResponse": {
+        "type": "object",
+        "properties": {
+          "user": { "$ref": "#/components/schemas/User" }
+        }
+      },
+      "TokenResponse": {
+        "type": "object",
+        "properties": {
+          "user": { "$ref": "#/components/schemas/User" },
+          "token": {
+            "type": "string",
+            "example": "oat_NA.SWVwanlJUmVTVzNEdVJxVjY4Ql9Rck9aSFVJd0V1M2gwRUgxdUYyMTk5MTg0NzM3Mg"
+          },
+          "refreshToken": {
+            "type": "string",
+            "example": "oat_NQ.OE1CMUpqVnJUdGp1S3hNcjhlSkh6UTlLVHYzcUVMZ2tncHltbjA0eDY1NDIwNzM2"
+          },
+          "type": { "type": "string", "example": "bearer" }
+        }
+      },
+      "RefreshRequest": {
+        "type": "object",
+        "properties": {
+          "refreshToken": { "type": "string" }
+        },
+        "required": ["refreshToken"]
+      },
+      "RefreshResponse": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string",
+            "example": "oat_NA.SWVwanlJUmVTVzNEdVJxVjY4Ql9Rck9aSFVJd0V1M2gwRUgxdUYyMTk5MTg0NzM3Mg"
+          },
+          "type": { "type": "string", "example": "bearer" }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "string", "example": "E_INVALID_REFRESH_TOKEN" },
+          "message": { "type": "string", "example": "Invalid or expired refresh token" },
+          "status": { "type": "boolean", "example": false }
+        }
       }
     }
   }

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -7,6 +7,7 @@ const DocsController = () => import('#controllers/docs_controller')
 const ApiInfoController = () => import('#controllers/api_info_controller')
 const AuthController = () => import('#controllers/auth_controller')
 const EmailVerificationController = () => import('#controllers/email_verification_controller')
+const TokenController = () => import('#controllers/token_controller')
 
 router.get('/', [RootController, 'handle'])
 router.get('/health', [HealthCheckController, 'handle'])
@@ -25,6 +26,8 @@ router
 
         router.post('/verify-email', [EmailVerificationController, 'verify'])
         router.post('/resend-verification', [EmailVerificationController, 'resend'])
+
+        router.post('/refresh-token', [TokenController, 'refresh'])
       })
       .prefix('/v1')
   })

--- a/tests/functional/token_controller.spec.ts
+++ b/tests/functional/token_controller.spec.ts
@@ -1,0 +1,59 @@
+import { test } from '@japa/runner'
+import { UserFactory } from '#database/factories/user_factory'
+import testUtils from '@adonisjs/core/services/test_utils'
+import TokenService from '#services/token_service'
+import db from '@adonisjs/lucid/services/db'
+
+test.group('Token Controller (functional)', (group) => {
+  let tokenService: TokenService
+
+  group.each.setup(() => {
+    tokenService = new TokenService()
+    return testUtils.db().withGlobalTransaction()
+  })
+
+  test('refresh endpoint returns new access token for valid refresh token', async ({
+    client,
+    assert,
+  }) => {
+    const user = await UserFactory.merge({ isVerified: true }).create()
+    const { token: refreshToken } = await tokenService.generateRefreshToken(user)
+
+    const response = await client.post('/api/v1/refresh-token').json({ refreshToken })
+
+    response.assertStatus(200)
+    const body = response.body()
+    assert.exists(body.token)
+    assert.equal(body.type, 'bearer')
+  })
+
+  test('refresh endpoint returns 401 / invalid token response for bad token', async ({
+    client,
+  }) => {
+    const response = await client
+      .post('/api/v1/refresh-token')
+      .json({ refreshToken: 'invalid_value' })
+
+    response.assertStatus(401)
+    response.assertBodyContains({
+      code: 'E_INVALID_REFRESH_TOKEN',
+    })
+  })
+  test('POST /token/refresh rotates refresh token and invalidates old one', async ({
+    client,
+    assert,
+  }) => {
+    const user = await UserFactory.merge({ isVerified: true }).create()
+    const { token: refreshToken, id: refreshId } = await tokenService.generateRefreshToken(user)
+    await tokenService.generateAuthToken(user, refreshId)
+
+    const response = await client.post('/api/v1/refresh-token').json({ refreshToken })
+    response.assertStatus(200)
+    const body = response.body()
+    assert.exists(body.refreshToken)
+    assert.exists(body.token)
+
+    const old = await db.query().from('auth_access_tokens').where('id', refreshId).first()
+    assert.isNull(old)
+  })
+})

--- a/tests/unit/auth_service.spec.ts
+++ b/tests/unit/auth_service.spec.ts
@@ -106,6 +106,8 @@ test.group('Auth Service', (group) => {
 
     assert.exists(result.token)
     assert.equal(result.type, 'bearer')
+    assert.exists(result.refreshToken)
+    assert.equal(result.type, 'bearer')
     assert.equal(result.user.email, user.email)
     assert.equal(result.user.username, user.username)
     assert.equal(user!.isVerified, 1)

--- a/tests/unit/token_service.spec.ts
+++ b/tests/unit/token_service.spec.ts
@@ -3,6 +3,8 @@ import TokenService from '#services/token_service'
 import User from '#models/user'
 import testUtils from '@adonisjs/core/services/test_utils'
 import { UserFactory } from '#database/factories/user_factory'
+import db from '@adonisjs/lucid/services/db'
+import InvalidRefreshTokenException from '#exceptions/invalid_refresh_token_exception'
 
 test.group('Token Service', (group) => {
   let tokenService: TokenService
@@ -39,5 +41,123 @@ test.group('Token Service', (group) => {
     const token2 = await tokenService.generateAuthToken(secondUser)
 
     assert.notEqual(token1, token2)
+  })
+
+  test('generateRefreshToken returns token and id', async ({ assert }) => {
+    const { token, id } = await tokenService.generateRefreshToken(user)
+
+    assert.isString(token)
+    assert.isNumber(id)
+
+    const row = await db.query().from('auth_access_tokens').where('id', id).first()
+    assert.exists(row)
+    assert.equal(row.name, 'refresh_token')
+    assert.deepEqual(JSON.parse(row.abilities), ['refresh'])
+  })
+
+  test('generateAuthToken links parent_id when refresh id provided', async ({ assert }) => {
+    const refresh = await tokenService.generateRefreshToken(user)
+    await tokenService.generateAuthToken(user, refresh.id)
+
+    const row = await db
+      .query()
+      .from('auth_access_tokens')
+      .where('tokenable_id', user.id as unknown as number)
+      .andWhere('name', 'api_token')
+      .orderBy('created_at', 'desc')
+      .first()
+
+    assert.exists(row)
+    assert.equal(row.parent_id, refresh.id)
+  })
+
+  test('refreshToken exchanges refresh token for new access token', async ({ assert }) => {
+    const refresh = await tokenService.generateRefreshToken(user)
+    const result = await tokenService.refreshToken(refresh.token)
+
+    assert.exists(result)
+    assert.isString(result.token)
+    assert.exists(result.refreshToken)
+
+    const newRefreshRow = await db
+      .query()
+      .from('auth_access_tokens')
+      .where('name', 'refresh_token')
+      .andWhereNot('id', refresh.id)
+      .orderBy('created_at', 'desc')
+      .first()
+
+    assert.exists(newRefreshRow)
+
+    const linkedRow = await db
+      .query()
+      .from('auth_access_tokens')
+      .where('tokenable_id', user.id as unknown as number)
+      .andWhere('parent_id', newRefreshRow.id)
+      .first()
+
+    assert.exists(linkedRow)
+
+    const oldAfter = await db.query().from('auth_access_tokens').where('id', refresh.id).first()
+    assert.isNull(oldAfter)
+  })
+
+  test('refreshToken throws InvalidRefreshTokenException for invalid token', async ({ assert }) => {
+    try {
+      await tokenService.refreshToken('invalid_token_value')
+      assert.fail('Should have thrown InvalidRefreshTokenException')
+    } catch (error) {
+      assert.instanceOf(error, InvalidRefreshTokenException)
+    }
+  })
+
+  test('using refresh token rotates and invalidates old refresh and its children', async ({
+    assert,
+  }) => {
+    const original = await tokenService.generateRefreshToken(user)
+    await tokenService.generateAuthToken(user, original.id)
+
+    const originalRow = await db.query().from('auth_access_tokens').where('id', original.id).first()
+    assert.exists(originalRow)
+
+    const childRow = await db
+      .query()
+      .from('auth_access_tokens')
+      .where('parent_id', original.id)
+      .first()
+    assert.exists(childRow)
+
+    // call refresh -> rotation should issue a new refresh + access token and remove the old refresh (and its children if FK CASCADE)
+    const result = await tokenService.refreshToken(original.token)
+    assert.exists(result.refreshToken)
+    assert.exists(result.token)
+
+    // old refresh should be gone
+    const oldAfter = await db.query().from('auth_access_tokens').where('id', original.id).first()
+    assert.isNull(oldAfter)
+
+    // children referencing old refresh should be gone (CASCADE) or at least not reference the old id
+    const orphan = await db
+      .query()
+      .from('auth_access_tokens')
+      .where('parent_id', original.id)
+      .first()
+    assert.isNull(orphan)
+
+    const newRefreshRow = await db
+      .query()
+      .from('auth_access_tokens')
+      .where('name', 'refresh_token')
+      .andWhereNot('id', original.id)
+      .orderBy('created_at', 'desc')
+      .first()
+
+    assert.exists(newRefreshRow)
+    const linked = await db
+      .query()
+      .from('auth_access_tokens')
+      .where('parent_id', newRefreshRow.id)
+      .first()
+    assert.exists(linked)
   })
 })


### PR DESCRIPTION
## 📝 Description

Avant, notre système d'auth utilisait uniquement des access tokens de longue durée (7 jours), ce qui représente un risque de sécurité important si un token est compromis. Cette PR se charge d'implémenter un système de refresh tokens de réduire considérablement ce risque en utilisant des access tokens à courte durée de vie (15 minutes) tout en maintenant une bonne expérience utilisateur grâce aux refresh tokens de longue durée.

(Attendre d'adapter le httpClient en front avant de merged cette PR)

Related task : [WAR-45](https://sleeved.atlassian.net/browse/WAR-45)

## 📸 Screenshots / Demo

<img width="1030" height="866" alt="image" src="https://github.com/user-attachments/assets/f91d6d33-0b28-436b-8fa6-4e4ac1c19e47" />

## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Performance optimization verified (if applicable)
- [ ] Documentation updated (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[WAR-45]: https://sleeved.atlassian.net/browse/WAR-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ