### PR TITLE
feat(auth): add username and email availability check endpoints

### DIFF
--- a/app/controllers/availability_controller.ts
+++ b/app/controllers/availability_controller.ts
@@ -1,0 +1,39 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { inject } from '@adonisjs/core'
+import AvailabilityService from '#services/availability_service'
+
+@inject()
+export default class AvailabilityController {
+  constructor(protected availabilityService: AvailabilityService) {}
+
+  /**
+   * Check availability of email and/or username
+   * Query parameters:
+   * - email: string (optional)
+   * - username: string (optional)
+   *
+   * At least one parameter must be provided.
+   */
+  async check({ request, response }: HttpContext) {
+    const { email, username } = request.qs()
+    const result: { email?: { available: boolean }; username?: { available: boolean } } = {}
+
+    if (email === undefined && username === undefined) {
+      return response
+        .status(400)
+        .json({ error: 'At least one parameter (email or username) is required' })
+    }
+
+    if (email) {
+      const available = await this.availabilityService.isEmailAvailable(email)
+      result.email = { available }
+    }
+
+    if (username) {
+      const available = await this.availabilityService.isUsernameAvailable(username)
+      result.username = { available }
+    }
+
+    return response.ok(result)
+  }
+}

--- a/app/services/availability_service.ts
+++ b/app/services/availability_service.ts
@@ -1,0 +1,15 @@
+import User from '#models/user'
+import { inject } from '@adonisjs/core'
+
+@inject()
+export default class AvailabilityService {
+  async isEmailAvailable(email: string): Promise<boolean> {
+    const existingEmail = await User.query().where('email', email).first()
+    return !existingEmail
+  }
+
+  async isUsernameAvailable(username: string): Promise<boolean> {
+    const existingUsername = await User.query().where('username', username).first()
+    return !existingUsername
+  }
+}

--- a/resources/swagger.json
+++ b/resources/swagger.json
@@ -189,6 +189,114 @@
           }
         }
       }
+    },
+    "/availability": {
+      "get": {
+        "summary": "Check availability of username and/or email",
+        "tags": ["Auth"],
+        "description": "Check if a username and/or email address is available for registration.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "username",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Username to check",
+            "example": "alice_doe",
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "email",
+            "schema": {
+              "type": "string",
+              "format": "email"
+            },
+            "description": "Email to check",
+            "example": "alice@example.com",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Availability check results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "username": {
+                      "type": "object",
+                      "properties": {
+                        "available": { "type": "boolean" }
+                      }
+                    },
+                    "email": {
+                      "type": "object",
+                      "properties": {
+                        "available": { "type": "boolean" }
+                      }
+                    }
+                  }
+                },
+                "examples": {
+                  "usernameOnly": {
+                    "value": {
+                      "username": { "available": true }
+                    }
+                  },
+                  "emailOnly": {
+                    "value": {
+                      "email": { "available": false }
+                    }
+                  },
+                  "both": {
+                    "value": {
+                      "username": { "available": true },
+                      "email": { "available": false }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing required parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" }
+                  }
+                },
+                "example": {
+                  "error": "At least one parameter (email or username) is required"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {

--- a/start/routes.ts
+++ b/start/routes.ts
@@ -8,6 +8,7 @@ const ApiInfoController = () => import('#controllers/api_info_controller')
 const AuthController = () => import('#controllers/auth_controller')
 const EmailVerificationController = () => import('#controllers/email_verification_controller')
 const TokenController = () => import('#controllers/token_controller')
+const AvailabilityController = () => import('#controllers/availability_controller')
 
 router.get('/', [RootController, 'handle'])
 router.get('/health', [HealthCheckController, 'handle'])
@@ -23,6 +24,7 @@ router
         router.post('/register', [AuthController, 'register'])
         router.post('/login', [AuthController, 'login'])
         router.get('/me', [AuthController, 'me']).use(middleware.auth())
+        router.get('/availability', [AvailabilityController, 'check'])
 
         router.post('/verify-email', [EmailVerificationController, 'verify'])
         router.post('/resend-verification', [EmailVerificationController, 'resend'])

--- a/tests/functional/availability_controller.spec.ts
+++ b/tests/functional/availability_controller.spec.ts
@@ -1,0 +1,73 @@
+import { test } from '@japa/runner'
+import { UserFactory } from '#database/factories/user_factory'
+import testUtils from '@adonisjs/core/services/test_utils'
+
+test.group('Availability Controller', (group) => {
+  group.each.setup(() => {
+    return testUtils.db().withGlobalTransaction()
+  })
+
+  test('returns available=true for unused username', async ({ client }) => {
+    const response = await client.get('/api/v1/availability').qs({ username: 'newuser123' })
+
+    response.assertStatus(200)
+    response.assertBodyContains({
+      username: { available: true },
+    })
+  })
+
+  test('returns available=false for existing username', async ({ client }) => {
+    const user = await UserFactory.create()
+
+    const response = await client.get('/api/v1/availability').qs({ username: user.username })
+
+    response.assertStatus(200)
+    response.assertBodyContains({
+      username: { available: false },
+    })
+  })
+
+  test('returns available=true for unused email', async ({ client }) => {
+    const response = await client.get('/api/v1/availability').qs({ email: 'unused@example.com' })
+
+    response.assertStatus(200)
+    response.assertBodyContains({
+      email: { available: true },
+    })
+  })
+
+  test('returns available=false for existing email', async ({ client }) => {
+    const user = await UserFactory.create()
+
+    const response = await client.get('/api/v1/availability').qs({ email: user.email })
+
+    response.assertStatus(200)
+    response.assertBodyContains({
+      email: { available: false },
+    })
+  })
+
+  test('can check both email and username simultaneously', async ({ client }) => {
+    const user = await UserFactory.create()
+
+    const response = await client.get('/api/v1/availability').qs({
+      email: 'new@example.com',
+      username: user.username,
+    })
+
+    response.assertStatus(200)
+    response.assertBodyContains({
+      email: { available: true },
+      username: { available: false },
+    })
+  })
+
+  test('returns 400 when no parameters are provided', async ({ client }) => {
+    const response = await client.get('/api/v1/availability')
+
+    response.assertStatus(400)
+    response.assertBodyContains({
+      error: 'At least one parameter (email or username) is required',
+    })
+  })
+})


### PR DESCRIPTION
## 📝 Description

Implémentation de 2 nouveaux endpoints pour vérifier la disponibilité d'un username et d'une adresse email qu’on pourra utiliser en front avant l’inscription pour éviter de générer une erreur serveur à la fin du process d'inscription (on ajoute une vérification à chaque step)

Related task : [WAR-41](https://sleeved.atlassian.net/browse/WAR-41)

## 📸 Screenshots / Demo

<img width="1539" height="1057" alt="image" src="https://github.com/user-attachments/assets/c2ad73ba-57fb-4a95-bf21-e6cc11ff8eae" />

## ✅ Checklist

- [ ] Code follows project standards (lint, format)
- [ ] Performance optimization verified (if applicable)
- [ ] Documentation updated (if applicable)

## 📋 Notes for reviewers

<!-- Add comments, special notes or instructions for reviewers -->


[WAR-41]: https://sleeved.atlassian.net/browse/WAR-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ